### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,3 +1,7 @@
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 name: stale
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/toozuuu/ngxsmk-tel-input/security/code-scanning/2](https://github.com/toozuuu/ngxsmk-tel-input/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow or the specific job to restrict the `GITHUB_TOKEN` to only the permissions required by the `actions/stale` action. According to the [actions/stale documentation](https://github.com/actions/stale#permissions), the action requires `issues: write` and `pull-requests: write` permissions to label and close issues/PRs, and may also need `contents: read` for some operations. The best practice is to add the `permissions` block at the workflow root (applies to all jobs), but it can also be added at the job level. In this case, add the following block after the `name:` line and before `on:`:

```yaml
permissions:
  contents: read
  issues: write
  pull-requests: write
```

No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
