### PR TITLE
release: v1.8.3 - fix implicit form submission on Enter and ControlValueAccessor DI conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.3] - 2026-06-08
+
+### Fixed
+- **Form Submission on Enter**: Handled Enter keypress inside the input to programmatically request submission on the closest form, bypassing browser-implicit submission blocks caused by the nested search input in the dropdown.
+- **Value Accessor DI Conflict**: Limited the `NgControl` dependency injection lookup to the component's own element injector (`{ self: true }`), resolving runtime "No value accessor" errors when nested under wrapper components that also implement `ControlValueAccessor`.
+
 ## [1.8.2] - 2026-06-07
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ngxsmk-tel-input",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ngxsmk-tel-input",
-      "version": "1.8.2",
+      "version": "1.8.3",
       "license": "MIT",
       "dependencies": {
         "@angular/common": "~19.2.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngxsmk-tel-input",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Angular telephone input with intl-tel-input + libphonenumber-js",
   "license": "MIT",
   "publishConfig": {

--- a/projects/demo/src/app/app.component.ts
+++ b/projects/demo/src/app/app.component.ts
@@ -36,7 +36,7 @@ import { ProfileComponent } from '../../../examples/profile-management/profile.c
               </div>
               <div class="flex flex-col">
                 <span class="text-lg font-semibold text-tf-text-primary dark:text-tf-dark-text-primary">Ngxsmk Tel Input</span>
-                <span class="text-xs text-tf-text-tertiary dark:text-tf-dark-text-tertiary">v1.8.2</span>
+                <span class="text-xs text-tf-text-tertiary dark:text-tf-dark-text-tertiary">v1.8.3</span>
               </div>
             </div>
             <button 
@@ -159,7 +159,7 @@ import { ProfileComponent } from '../../../examples/profile-management/profile.c
                   <span class="material-icons text-xl sm:text-2xl text-tf-warning">info</span>
                 </div>
                 <div class="min-w-0 flex-1">
-                  <div class="text-xl sm:text-2xl font-bold text-tf-text-primary dark:text-tf-dark-text-primary truncate">v1.8.2</div>
+                  <div class="text-xl sm:text-2xl font-bold text-tf-text-primary dark:text-tf-dark-text-primary truncate">v1.8.3</div>
                   <div class="text-xs text-tf-text-tertiary dark:text-tf-dark-text-tertiary uppercase tracking-wider truncate">Version</div>
                 </div>
               </div>

--- a/projects/demo/src/index.html
+++ b/projects/demo/src/index.html
@@ -60,7 +60,7 @@
     "description": "Angular telephone input component with country dropdown, flags, and robust validation/formatting. Wraps intl-tel-input for the UI and libphonenumber-js for parsing/validation.",
     "url": "https://github.com/NGXSMK/ngxsmk-tel-input",
     "downloadUrl": "https://www.npmjs.com/package/ngxsmk-tel-input",
-    "softwareVersion": "1.8.2",
+    "softwareVersion": "1.8.3",
     "releaseNotes": "Enhanced validation, mobile responsiveness, accessibility improvements, theme support",
     "author": {
       "@type": "Person",

--- a/projects/ngxsmk-tel-input/package.json
+++ b/projects/ngxsmk-tel-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngxsmk-tel-input",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Angular international telephone input (intl-tel-input UI + libphonenumber-js validation). ControlValueAccessor. SSR-safe.",
   "license": "MIT",
   "sideEffects": false,

--- a/projects/ngxsmk-tel-input/schematics/ng-add/index.ts
+++ b/projects/ngxsmk-tel-input/schematics/ng-add/index.ts
@@ -77,7 +77,7 @@ function addDependencies(): Rule {
     }
 
     // Add required dependencies
-    packageJsonContent.dependencies['ngxsmk-tel-input'] = '^1.8.2';
+    packageJsonContent.dependencies['ngxsmk-tel-input'] = '^1.8.3';
     packageJsonContent.dependencies['intl-tel-input'] = '^25.3.2';
     packageJsonContent.dependencies['libphonenumber-js'] = '^1.12.11';
 

--- a/projects/ngxsmk-tel-input/src/lib/ngxsmk-tel-input.component.spec.ts
+++ b/projects/ngxsmk-tel-input/src/lib/ngxsmk-tel-input.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { PLATFORM_ID, Component } from '@angular/core';
-import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { PLATFORM_ID, Component, forwardRef } from '@angular/core';
+import { FormControl, ReactiveFormsModule, NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { NgxsmkTelInputComponent } from './ngxsmk-tel-input.component';
@@ -638,6 +638,45 @@ describe('NgxsmkTelInputComponent', () => {
       expect(telInput).toBeTruthy();
     });
   });
+
+  describe('Form Integration and DI fixes', () => {
+    it('should submit closest form on Enter keypress', () => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [TestFormSubmissionComponent],
+        providers: [NgxsmkTelInputService]
+      });
+
+      const wrapperFixture = TestBed.createComponent(TestFormSubmissionComponent);
+      wrapperFixture.detectChanges();
+
+      const componentInstance = wrapperFixture.componentInstance;
+      const submitSpy = spyOn(componentInstance, 'onSubmit').and.callThrough();
+
+      const inputEl = wrapperFixture.nativeElement.querySelector('input');
+      expect(inputEl).toBeTruthy();
+
+      const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
+      inputEl.dispatchEvent(event);
+      wrapperFixture.detectChanges();
+
+      expect(submitSpy).toHaveBeenCalled();
+      expect(componentInstance.submitted).toBeTrue();
+    });
+
+    it('should not throw runtime error when nested under a CVA component that uses formControl', () => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [TestParentControlComponent],
+        providers: [NgxsmkTelInputService]
+      });
+
+      expect(() => {
+        const wrapperFixture = TestBed.createComponent(TestParentControlComponent);
+        wrapperFixture.detectChanges();
+      }).not.toThrow();
+    });
+  });
 });
 
 @Component({
@@ -651,5 +690,51 @@ describe('NgxsmkTelInputComponent', () => {
 })
 class TestMatFormFieldWrapperComponent {
   phoneControl = new FormControl('');
+}
+
+@Component({
+  template: `
+    <form (submit)="onSubmit($event)">
+      <ngxsmk-tel-input></ngxsmk-tel-input>
+    </form>
+  `,
+  standalone: true,
+  imports: [NgxsmkTelInputComponent]
+})
+class TestFormSubmissionComponent {
+  submitted = false;
+  onSubmit(event: Event) {
+    event.preventDefault();
+    this.submitted = true;
+  }
+}
+
+@Component({
+  selector: 'wrapper-cva',
+  template: `<ngxsmk-tel-input></ngxsmk-tel-input>`,
+  standalone: true,
+  imports: [NgxsmkTelInputComponent],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => WrapperCvaComponent),
+      multi: true
+    }
+  ]
+})
+class WrapperCvaComponent implements ControlValueAccessor {
+  writeValue(obj: any): void {}
+  registerOnChange(fn: any): void {}
+  registerOnTouched(fn: any): void {}
+  setDisabledState?(isDisabled: boolean): void {}
+}
+
+@Component({
+  template: `<wrapper-cva [formControl]="control"></wrapper-cva>`,
+  standalone: true,
+  imports: [WrapperCvaComponent, ReactiveFormsModule]
+})
+class TestParentControlComponent {
+  control = new FormControl('');
 }
 

--- a/projects/ngxsmk-tel-input/src/lib/ngxsmk-tel-input.component.ts
+++ b/projects/ngxsmk-tel-input/src/lib/ngxsmk-tel-input.component.ts
@@ -170,6 +170,7 @@ interface BeforeInputEvent extends Event {
             [attr.aria-errormessage]="showError() && resolvedErrorText() && (showErrorMsgSignal() ?? showErrorMsg) ? resolvedId + '-error' : null"
             (blur)="onBlur()"
             (focus)="onFocus()"
+            (keydown.enter)="onEnterPressed($event)"
           />
         </div>
 
@@ -233,7 +234,7 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterViewInit, 
   isNativelyDisabled = false;
 
   ngOnInit(): void {
-    this.ngControl = this.injector.get(NgControl, null);
+    this.ngControl = this.injector.get(NgControl, null, { optional: true, self: true } as any);
   }
 
   ngDoCheck(): void {
@@ -1285,6 +1286,18 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterViewInit, 
         }
       }
     });
+  }
+
+  onEnterPressed(event: Event) {
+    if (this.isDestroyed) return;
+    const form = this.hostElementRef.nativeElement.closest('form');
+    if (form) {
+      if (typeof form.requestSubmit === 'function') {
+        form.requestSubmit();
+      } else {
+        form.dispatchEvent(new Event('submit', { cancelable: true, bubbles: true }));
+      }
+    }
   }
 
   private handleInput() {


### PR DESCRIPTION
## Overview
This PR resolves two major usability issues with form integration when using the component within custom wrapper components (e.g., `<intl-phone>`), and bumps the project-wide version to **1.8.3**.

## Fixed Issues

1. **Implicit Form Submission on Enter Keypress**
   - **Problem**: Hitting `ENTER` inside the phone input did not submit the form because the internal dropdown search inputs triggered browser restrictions on implicit form submissions.
   - **Fix**: Added a `(keydown.enter)` listener that programmatically requests submission on the closest form, ensuring reliable behavior.
   - **Verification**: Verified using a new unit test: `'should submit closest form on Enter keypress'`.

2. **ControlValueAccessor Dependency Injection Conflict**
   - **Problem**: Wrapping `<ngxsmk-tel-input>` inside a parent component implementing `ControlValueAccessor` (like `<intl-phone>`) caused a DI lookup conflict where the child component incorrectly retrieved the parent's `NgControl`, throwing the runtime error: `No value accessor for form control with unspecified name attribute`.
   - **Fix**: Restricted the `NgControl` injection lookup to the element's local injector using `{ self: true }`.
   - **Verification**: Verified using a new unit test: `'should not throw runtime error when nested under a CVA component that uses formControl'`.

## Version Upgrades (v1.8.3)
Bumped the version number across the project configuration and metadata:
- Root `package.json` & `package-lock.json`
- Library `package.json`
- Schematic default installer dependencies (`ng-add`)
- Demo documentation page & JSON-LD metadata
- Updated `CHANGELOG.md`