### PR TITLE
release: v1.8.4 — fix No Value Accessor, touched during init, and Submit on Enter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.8.4] - 2026-06-08
+## [1.8.4-beta.0] - 2026-06-08
 
 ### Fixed
 - **Value Accessor DI Conflict (NG01203)**: Removed duplicate `NG_VALUE_ACCESSOR` and `NG_VALIDATORS` providers from component metadata, and refactored the component to manually inject `NgControl` and assign `valueAccessor = this` inside the constructor. This completely resolves runtime circular dependency and "No value accessor" errors across template-driven and reactive forms.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.4-beta.1] - 2026-06-08
+
+### Fixed
+- **Angular Signals NG0600 Error during Reinitialization**: Detached old event listeners (`cleanupEventListeners()`) prior to destroying the `intl-tel-input` instance during component/plugin reinitialization. This prevents DOM-triggered blur event handlers from writing to signals during Angular's effect execution context, and resolves memory leaks.
+
 ## [1.8.4-beta.0] - 2026-06-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.8.3] - 2026-06-08
+## [1.8.4] - 2026-06-08
 
 ### Fixed
-- **Form Submission on Enter**: Handled Enter keypress inside the input to programmatically request submission on the closest form, bypassing browser-implicit submission blocks caused by the nested search input in the dropdown.
-- **Value Accessor DI Conflict**: Limited the `NgControl` dependency injection lookup to the component's own element injector (`{ self: true }`), resolving runtime "No value accessor" errors when nested under wrapper components that also implement `ControlValueAccessor`.
+- **Value Accessor DI Conflict (NG01203)**: Removed duplicate `NG_VALUE_ACCESSOR` and `NG_VALIDATORS` providers from component metadata, and refactored the component to manually inject `NgControl` and assign `valueAccessor = this` inside the constructor. This completely resolves runtime circular dependency and "No value accessor" errors across template-driven and reactive forms.
+- **Form Touched State on Enter**: Programmatically marked the control as `touched` when the form is submitted via Enter keypress, ensuring the touched state is correctly set to true on the first submission.
 
 ## [1.8.2] - 2026-06-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.4] - 2026-06-10
+
+### Fixed
+- **No Value Accessor (NG01203)**: Added `ReactiveFormsModule` and `FormsModule` to component imports and `NG_VALUE_ACCESSOR` to `viewProviders` alongside `providers`, ensuring proper resolution for standalone components across all Angular DI scopes.
+- **Touched State During Initialization**: Removed the 50ms `setTimeout` delay on `initialized` flag and eliminated the redundant native blur event listener to prevent race conditions where intl-tel-input plugin events during setup could prematurely mark the field as touched.
+- **Submit on Enter with [formGroup]**: Removed `event.preventDefault()` and manual `setTimeout` submission logic from `onEnterPressed()`. The browser's native Enter key behavior now triggers the submit button click naturally, which correctly fires Angular's `(ngSubmit)` handler.
+
 ## [1.8.4-beta.1] - 2026-06-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -508,4 +508,4 @@ Clear `.angular/cache`, rebuild the lib, and restart `ng serve`.
 * UI powered by [`intl-tel-input`](https://github.com/jackocnr/intl-tel-input)
 * Parsing & validation by [`libphonenumber-js`](https://github.com/catamphetamine/libphonenumber-js)
 
-Last updated: 2026-06-07
+Last updated: 2026-06-08

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ngxsmk-tel-input",
-  "version": "1.8.4",
+  "version": "1.8.4-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ngxsmk-tel-input",
-      "version": "1.8.4",
+      "version": "1.8.4-beta.0",
       "license": "MIT",
       "dependencies": {
         "@angular/common": "~19.2.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ngxsmk-tel-input",
-  "version": "1.8.4-beta.4",
+  "version": "1.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ngxsmk-tel-input",
-      "version": "1.8.4-beta.4",
+      "version": "1.8.4",
       "license": "MIT",
       "dependencies": {
         "@angular/common": "~19.2.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ngxsmk-tel-input",
-  "version": "1.8.4-beta.3",
+  "version": "1.8.4-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ngxsmk-tel-input",
-      "version": "1.8.4-beta.3",
+      "version": "1.8.4-beta.4",
       "license": "MIT",
       "dependencies": {
         "@angular/common": "~19.2.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ngxsmk-tel-input",
-  "version": "1.8.4-beta.1",
+  "version": "1.8.4-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ngxsmk-tel-input",
-      "version": "1.8.4-beta.1",
+      "version": "1.8.4-beta.2",
       "license": "MIT",
       "dependencies": {
         "@angular/common": "~19.2.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ngxsmk-tel-input",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ngxsmk-tel-input",
-      "version": "1.8.3",
+      "version": "1.8.4",
       "license": "MIT",
       "dependencies": {
         "@angular/common": "~19.2.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ngxsmk-tel-input",
-  "version": "1.8.4-beta.2",
+  "version": "1.8.4-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ngxsmk-tel-input",
-      "version": "1.8.4-beta.2",
+      "version": "1.8.4-beta.3",
       "license": "MIT",
       "dependencies": {
         "@angular/common": "~19.2.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ngxsmk-tel-input",
-  "version": "1.8.4-beta.0",
+  "version": "1.8.4-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ngxsmk-tel-input",
-      "version": "1.8.4-beta.0",
+      "version": "1.8.4-beta.1",
       "license": "MIT",
       "dependencies": {
         "@angular/common": "~19.2.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngxsmk-tel-input",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "Angular telephone input with intl-tel-input + libphonenumber-js",
   "license": "MIT",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngxsmk-tel-input",
-  "version": "1.8.4-beta.1",
+  "version": "1.8.4-beta.2",
   "description": "Angular telephone input with intl-tel-input + libphonenumber-js",
   "license": "MIT",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngxsmk-tel-input",
-  "version": "1.8.4-beta.0",
+  "version": "1.8.4-beta.1",
   "description": "Angular telephone input with intl-tel-input + libphonenumber-js",
   "license": "MIT",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngxsmk-tel-input",
-  "version": "1.8.4-beta.4",
+  "version": "1.8.4",
   "description": "Angular telephone input with intl-tel-input + libphonenumber-js",
   "license": "MIT",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngxsmk-tel-input",
-  "version": "1.8.4",
+  "version": "1.8.4-beta.0",
   "description": "Angular telephone input with intl-tel-input + libphonenumber-js",
   "license": "MIT",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngxsmk-tel-input",
-  "version": "1.8.4-beta.2",
+  "version": "1.8.4-beta.3",
   "description": "Angular telephone input with intl-tel-input + libphonenumber-js",
   "license": "MIT",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngxsmk-tel-input",
-  "version": "1.8.4-beta.3",
+  "version": "1.8.4-beta.4",
   "description": "Angular telephone input with intl-tel-input + libphonenumber-js",
   "license": "MIT",
   "publishConfig": {

--- a/projects/demo/src/app/app.component.ts
+++ b/projects/demo/src/app/app.component.ts
@@ -36,7 +36,7 @@ import { ProfileComponent } from '../../../examples/profile-management/profile.c
               </div>
               <div class="flex flex-col">
                 <span class="text-lg font-semibold text-tf-text-primary dark:text-tf-dark-text-primary">Ngxsmk Tel Input</span>
-                <span class="text-xs text-tf-text-tertiary dark:text-tf-dark-text-tertiary">v1.8.4-beta.2</span>
+                <span class="text-xs text-tf-text-tertiary dark:text-tf-dark-text-tertiary">v1.8.4-beta.3</span>
               </div>
             </div>
             <button 
@@ -159,7 +159,7 @@ import { ProfileComponent } from '../../../examples/profile-management/profile.c
                   <span class="material-icons text-xl sm:text-2xl text-tf-warning">info</span>
                 </div>
                 <div class="min-w-0 flex-1">
-                  <div class="text-xl sm:text-2xl font-bold text-tf-text-primary dark:text-tf-dark-text-primary truncate">v1.8.4-beta.2</div>
+                  <div class="text-xl sm:text-2xl font-bold text-tf-text-primary dark:text-tf-dark-text-primary truncate">v1.8.4-beta.3</div>
                   <div class="text-xs text-tf-text-tertiary dark:text-tf-dark-text-tertiary uppercase tracking-wider truncate">Version</div>
                 </div>
               </div>

--- a/projects/demo/src/app/app.component.ts
+++ b/projects/demo/src/app/app.component.ts
@@ -36,7 +36,7 @@ import { ProfileComponent } from '../../../examples/profile-management/profile.c
               </div>
               <div class="flex flex-col">
                 <span class="text-lg font-semibold text-tf-text-primary dark:text-tf-dark-text-primary">Ngxsmk Tel Input</span>
-                <span class="text-xs text-tf-text-tertiary dark:text-tf-dark-text-tertiary">v1.8.4-beta.4</span>
+                <span class="text-xs text-tf-text-tertiary dark:text-tf-dark-text-tertiary">v1.8.4</span>
               </div>
             </div>
             <button 
@@ -159,7 +159,7 @@ import { ProfileComponent } from '../../../examples/profile-management/profile.c
                   <span class="material-icons text-xl sm:text-2xl text-tf-warning">info</span>
                 </div>
                 <div class="min-w-0 flex-1">
-                  <div class="text-xl sm:text-2xl font-bold text-tf-text-primary dark:text-tf-dark-text-primary truncate">v1.8.4-beta.4</div>
+                  <div class="text-xl sm:text-2xl font-bold text-tf-text-primary dark:text-tf-dark-text-primary truncate">v1.8.4</div>
                   <div class="text-xs text-tf-text-tertiary dark:text-tf-dark-text-tertiary uppercase tracking-wider truncate">Version</div>
                 </div>
               </div>

--- a/projects/demo/src/app/app.component.ts
+++ b/projects/demo/src/app/app.component.ts
@@ -36,7 +36,7 @@ import { ProfileComponent } from '../../../examples/profile-management/profile.c
               </div>
               <div class="flex flex-col">
                 <span class="text-lg font-semibold text-tf-text-primary dark:text-tf-dark-text-primary">Ngxsmk Tel Input</span>
-                <span class="text-xs text-tf-text-tertiary dark:text-tf-dark-text-tertiary">v1.8.3</span>
+                <span class="text-xs text-tf-text-tertiary dark:text-tf-dark-text-tertiary">v1.8.4</span>
               </div>
             </div>
             <button 
@@ -159,7 +159,7 @@ import { ProfileComponent } from '../../../examples/profile-management/profile.c
                   <span class="material-icons text-xl sm:text-2xl text-tf-warning">info</span>
                 </div>
                 <div class="min-w-0 flex-1">
-                  <div class="text-xl sm:text-2xl font-bold text-tf-text-primary dark:text-tf-dark-text-primary truncate">v1.8.3</div>
+                  <div class="text-xl sm:text-2xl font-bold text-tf-text-primary dark:text-tf-dark-text-primary truncate">v1.8.4</div>
                   <div class="text-xs text-tf-text-tertiary dark:text-tf-dark-text-tertiary uppercase tracking-wider truncate">Version</div>
                 </div>
               </div>

--- a/projects/demo/src/app/app.component.ts
+++ b/projects/demo/src/app/app.component.ts
@@ -36,7 +36,7 @@ import { ProfileComponent } from '../../../examples/profile-management/profile.c
               </div>
               <div class="flex flex-col">
                 <span class="text-lg font-semibold text-tf-text-primary dark:text-tf-dark-text-primary">Ngxsmk Tel Input</span>
-                <span class="text-xs text-tf-text-tertiary dark:text-tf-dark-text-tertiary">v1.8.4-beta.1</span>
+                <span class="text-xs text-tf-text-tertiary dark:text-tf-dark-text-tertiary">v1.8.4-beta.2</span>
               </div>
             </div>
             <button 
@@ -159,7 +159,7 @@ import { ProfileComponent } from '../../../examples/profile-management/profile.c
                   <span class="material-icons text-xl sm:text-2xl text-tf-warning">info</span>
                 </div>
                 <div class="min-w-0 flex-1">
-                  <div class="text-xl sm:text-2xl font-bold text-tf-text-primary dark:text-tf-dark-text-primary truncate">v1.8.4-beta.1</div>
+                  <div class="text-xl sm:text-2xl font-bold text-tf-text-primary dark:text-tf-dark-text-primary truncate">v1.8.4-beta.2</div>
                   <div class="text-xs text-tf-text-tertiary dark:text-tf-dark-text-tertiary uppercase tracking-wider truncate">Version</div>
                 </div>
               </div>

--- a/projects/demo/src/app/app.component.ts
+++ b/projects/demo/src/app/app.component.ts
@@ -36,7 +36,7 @@ import { ProfileComponent } from '../../../examples/profile-management/profile.c
               </div>
               <div class="flex flex-col">
                 <span class="text-lg font-semibold text-tf-text-primary dark:text-tf-dark-text-primary">Ngxsmk Tel Input</span>
-                <span class="text-xs text-tf-text-tertiary dark:text-tf-dark-text-tertiary">v1.8.4-beta.0</span>
+                <span class="text-xs text-tf-text-tertiary dark:text-tf-dark-text-tertiary">v1.8.4-beta.1</span>
               </div>
             </div>
             <button 
@@ -159,7 +159,7 @@ import { ProfileComponent } from '../../../examples/profile-management/profile.c
                   <span class="material-icons text-xl sm:text-2xl text-tf-warning">info</span>
                 </div>
                 <div class="min-w-0 flex-1">
-                  <div class="text-xl sm:text-2xl font-bold text-tf-text-primary dark:text-tf-dark-text-primary truncate">v1.8.4-beta.0</div>
+                  <div class="text-xl sm:text-2xl font-bold text-tf-text-primary dark:text-tf-dark-text-primary truncate">v1.8.4-beta.1</div>
                   <div class="text-xs text-tf-text-tertiary dark:text-tf-dark-text-tertiary uppercase tracking-wider truncate">Version</div>
                 </div>
               </div>

--- a/projects/demo/src/app/app.component.ts
+++ b/projects/demo/src/app/app.component.ts
@@ -36,7 +36,7 @@ import { ProfileComponent } from '../../../examples/profile-management/profile.c
               </div>
               <div class="flex flex-col">
                 <span class="text-lg font-semibold text-tf-text-primary dark:text-tf-dark-text-primary">Ngxsmk Tel Input</span>
-                <span class="text-xs text-tf-text-tertiary dark:text-tf-dark-text-tertiary">v1.8.4-beta.3</span>
+                <span class="text-xs text-tf-text-tertiary dark:text-tf-dark-text-tertiary">v1.8.4-beta.4</span>
               </div>
             </div>
             <button 
@@ -159,7 +159,7 @@ import { ProfileComponent } from '../../../examples/profile-management/profile.c
                   <span class="material-icons text-xl sm:text-2xl text-tf-warning">info</span>
                 </div>
                 <div class="min-w-0 flex-1">
-                  <div class="text-xl sm:text-2xl font-bold text-tf-text-primary dark:text-tf-dark-text-primary truncate">v1.8.4-beta.3</div>
+                  <div class="text-xl sm:text-2xl font-bold text-tf-text-primary dark:text-tf-dark-text-primary truncate">v1.8.4-beta.4</div>
                   <div class="text-xs text-tf-text-tertiary dark:text-tf-dark-text-tertiary uppercase tracking-wider truncate">Version</div>
                 </div>
               </div>

--- a/projects/demo/src/app/app.component.ts
+++ b/projects/demo/src/app/app.component.ts
@@ -36,7 +36,7 @@ import { ProfileComponent } from '../../../examples/profile-management/profile.c
               </div>
               <div class="flex flex-col">
                 <span class="text-lg font-semibold text-tf-text-primary dark:text-tf-dark-text-primary">Ngxsmk Tel Input</span>
-                <span class="text-xs text-tf-text-tertiary dark:text-tf-dark-text-tertiary">v1.8.4</span>
+                <span class="text-xs text-tf-text-tertiary dark:text-tf-dark-text-tertiary">v1.8.4-beta.0</span>
               </div>
             </div>
             <button 
@@ -159,7 +159,7 @@ import { ProfileComponent } from '../../../examples/profile-management/profile.c
                   <span class="material-icons text-xl sm:text-2xl text-tf-warning">info</span>
                 </div>
                 <div class="min-w-0 flex-1">
-                  <div class="text-xl sm:text-2xl font-bold text-tf-text-primary dark:text-tf-dark-text-primary truncate">v1.8.4</div>
+                  <div class="text-xl sm:text-2xl font-bold text-tf-text-primary dark:text-tf-dark-text-primary truncate">v1.8.4-beta.0</div>
                   <div class="text-xs text-tf-text-tertiary dark:text-tf-dark-text-tertiary uppercase tracking-wider truncate">Version</div>
                 </div>
               </div>

--- a/projects/demo/src/index.html
+++ b/projects/demo/src/index.html
@@ -60,7 +60,7 @@
     "description": "Angular telephone input component with country dropdown, flags, and robust validation/formatting. Wraps intl-tel-input for the UI and libphonenumber-js for parsing/validation.",
     "url": "https://github.com/NGXSMK/ngxsmk-tel-input",
     "downloadUrl": "https://www.npmjs.com/package/ngxsmk-tel-input",
-    "softwareVersion": "1.8.4",
+    "softwareVersion": "1.8.4-beta.0",
     "releaseNotes": "Enhanced validation, mobile responsiveness, accessibility improvements, theme support",
     "author": {
       "@type": "Person",

--- a/projects/demo/src/index.html
+++ b/projects/demo/src/index.html
@@ -60,7 +60,7 @@
     "description": "Angular telephone input component with country dropdown, flags, and robust validation/formatting. Wraps intl-tel-input for the UI and libphonenumber-js for parsing/validation.",
     "url": "https://github.com/NGXSMK/ngxsmk-tel-input",
     "downloadUrl": "https://www.npmjs.com/package/ngxsmk-tel-input",
-    "softwareVersion": "1.8.3",
+    "softwareVersion": "1.8.4",
     "releaseNotes": "Enhanced validation, mobile responsiveness, accessibility improvements, theme support",
     "author": {
       "@type": "Person",

--- a/projects/demo/src/index.html
+++ b/projects/demo/src/index.html
@@ -60,7 +60,7 @@
     "description": "Angular telephone input component with country dropdown, flags, and robust validation/formatting. Wraps intl-tel-input for the UI and libphonenumber-js for parsing/validation.",
     "url": "https://github.com/NGXSMK/ngxsmk-tel-input",
     "downloadUrl": "https://www.npmjs.com/package/ngxsmk-tel-input",
-    "softwareVersion": "1.8.4-beta.1",
+    "softwareVersion": "1.8.4-beta.2",
     "releaseNotes": "Enhanced validation, mobile responsiveness, accessibility improvements, theme support",
     "author": {
       "@type": "Person",

--- a/projects/demo/src/index.html
+++ b/projects/demo/src/index.html
@@ -60,7 +60,7 @@
     "description": "Angular telephone input component with country dropdown, flags, and robust validation/formatting. Wraps intl-tel-input for the UI and libphonenumber-js for parsing/validation.",
     "url": "https://github.com/NGXSMK/ngxsmk-tel-input",
     "downloadUrl": "https://www.npmjs.com/package/ngxsmk-tel-input",
-    "softwareVersion": "1.8.4-beta.2",
+    "softwareVersion": "1.8.4-beta.3",
     "releaseNotes": "Enhanced validation, mobile responsiveness, accessibility improvements, theme support",
     "author": {
       "@type": "Person",

--- a/projects/demo/src/index.html
+++ b/projects/demo/src/index.html
@@ -60,7 +60,7 @@
     "description": "Angular telephone input component with country dropdown, flags, and robust validation/formatting. Wraps intl-tel-input for the UI and libphonenumber-js for parsing/validation.",
     "url": "https://github.com/NGXSMK/ngxsmk-tel-input",
     "downloadUrl": "https://www.npmjs.com/package/ngxsmk-tel-input",
-    "softwareVersion": "1.8.4-beta.0",
+    "softwareVersion": "1.8.4-beta.1",
     "releaseNotes": "Enhanced validation, mobile responsiveness, accessibility improvements, theme support",
     "author": {
       "@type": "Person",

--- a/projects/demo/src/index.html
+++ b/projects/demo/src/index.html
@@ -60,7 +60,7 @@
     "description": "Angular telephone input component with country dropdown, flags, and robust validation/formatting. Wraps intl-tel-input for the UI and libphonenumber-js for parsing/validation.",
     "url": "https://github.com/NGXSMK/ngxsmk-tel-input",
     "downloadUrl": "https://www.npmjs.com/package/ngxsmk-tel-input",
-    "softwareVersion": "1.8.4-beta.4",
+    "softwareVersion": "1.8.4",
     "releaseNotes": "Enhanced validation, mobile responsiveness, accessibility improvements, theme support",
     "author": {
       "@type": "Person",

--- a/projects/demo/src/index.html
+++ b/projects/demo/src/index.html
@@ -60,7 +60,7 @@
     "description": "Angular telephone input component with country dropdown, flags, and robust validation/formatting. Wraps intl-tel-input for the UI and libphonenumber-js for parsing/validation.",
     "url": "https://github.com/NGXSMK/ngxsmk-tel-input",
     "downloadUrl": "https://www.npmjs.com/package/ngxsmk-tel-input",
-    "softwareVersion": "1.8.4-beta.3",
+    "softwareVersion": "1.8.4-beta.4",
     "releaseNotes": "Enhanced validation, mobile responsiveness, accessibility improvements, theme support",
     "author": {
       "@type": "Person",

--- a/projects/demo/src/styles.scss
+++ b/projects/demo/src/styles.scss
@@ -84,7 +84,7 @@ textarea {
   color: #1e293b !important;
   border: 1px solid #d1d5db !important;
   outline: none !important;
-  padding: 10px 12px !important;
+  padding: 10px 36px !important;
   width: 100% !important;
   font-size: 14px !important;
   border-radius: 0 !important;

--- a/projects/ngxsmk-tel-input/README.md
+++ b/projects/ngxsmk-tel-input/README.md
@@ -423,4 +423,4 @@ Clear `.angular/cache`, rebuild the lib, and restart `ng serve`.
 * UI powered by [`intl-tel-input`](https://github.com/jackocnr/intl-tel-input)
 * Parsing & validation by [`libphonenumber-js`](https://github.com/catamphetamine/libphonenumber-js)
 
-Last updated: 2026-06-07
+Last updated: 2026-06-08

--- a/projects/ngxsmk-tel-input/package.json
+++ b/projects/ngxsmk-tel-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngxsmk-tel-input",
-  "version": "1.8.4-beta.1",
+  "version": "1.8.4-beta.2",
   "description": "Angular international telephone input (intl-tel-input UI + libphonenumber-js validation). ControlValueAccessor. SSR-safe.",
   "license": "MIT",
   "sideEffects": false,

--- a/projects/ngxsmk-tel-input/package.json
+++ b/projects/ngxsmk-tel-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngxsmk-tel-input",
-  "version": "1.8.4-beta.2",
+  "version": "1.8.4-beta.3",
   "description": "Angular international telephone input (intl-tel-input UI + libphonenumber-js validation). ControlValueAccessor. SSR-safe.",
   "license": "MIT",
   "sideEffects": false,

--- a/projects/ngxsmk-tel-input/package.json
+++ b/projects/ngxsmk-tel-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngxsmk-tel-input",
-  "version": "1.8.4",
+  "version": "1.8.4-beta.0",
   "description": "Angular international telephone input (intl-tel-input UI + libphonenumber-js validation). ControlValueAccessor. SSR-safe.",
   "license": "MIT",
   "sideEffects": false,

--- a/projects/ngxsmk-tel-input/package.json
+++ b/projects/ngxsmk-tel-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngxsmk-tel-input",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "Angular international telephone input (intl-tel-input UI + libphonenumber-js validation). ControlValueAccessor. SSR-safe.",
   "license": "MIT",
   "sideEffects": false,

--- a/projects/ngxsmk-tel-input/package.json
+++ b/projects/ngxsmk-tel-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngxsmk-tel-input",
-  "version": "1.8.4-beta.3",
+  "version": "1.8.4-beta.4",
   "description": "Angular international telephone input (intl-tel-input UI + libphonenumber-js validation). ControlValueAccessor. SSR-safe.",
   "license": "MIT",
   "sideEffects": false,

--- a/projects/ngxsmk-tel-input/package.json
+++ b/projects/ngxsmk-tel-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngxsmk-tel-input",
-  "version": "1.8.4-beta.4",
+  "version": "1.8.4",
   "description": "Angular international telephone input (intl-tel-input UI + libphonenumber-js validation). ControlValueAccessor. SSR-safe.",
   "license": "MIT",
   "sideEffects": false,

--- a/projects/ngxsmk-tel-input/package.json
+++ b/projects/ngxsmk-tel-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngxsmk-tel-input",
-  "version": "1.8.4-beta.0",
+  "version": "1.8.4-beta.1",
   "description": "Angular international telephone input (intl-tel-input UI + libphonenumber-js validation). ControlValueAccessor. SSR-safe.",
   "license": "MIT",
   "sideEffects": false,

--- a/projects/ngxsmk-tel-input/schematics/ng-add/index.ts
+++ b/projects/ngxsmk-tel-input/schematics/ng-add/index.ts
@@ -77,7 +77,7 @@ function addDependencies(): Rule {
     }
 
     // Add required dependencies
-    packageJsonContent.dependencies['ngxsmk-tel-input'] = '^1.8.4';
+    packageJsonContent.dependencies['ngxsmk-tel-input'] = '^1.8.4-beta.0';
     packageJsonContent.dependencies['intl-tel-input'] = '^25.3.2';
     packageJsonContent.dependencies['libphonenumber-js'] = '^1.12.11';
 

--- a/projects/ngxsmk-tel-input/schematics/ng-add/index.ts
+++ b/projects/ngxsmk-tel-input/schematics/ng-add/index.ts
@@ -77,7 +77,7 @@ function addDependencies(): Rule {
     }
 
     // Add required dependencies
-    packageJsonContent.dependencies['ngxsmk-tel-input'] = '^1.8.4-beta.1';
+    packageJsonContent.dependencies['ngxsmk-tel-input'] = '^1.8.4-beta.2';
     packageJsonContent.dependencies['intl-tel-input'] = '^25.3.2';
     packageJsonContent.dependencies['libphonenumber-js'] = '^1.12.11';
 

--- a/projects/ngxsmk-tel-input/schematics/ng-add/index.ts
+++ b/projects/ngxsmk-tel-input/schematics/ng-add/index.ts
@@ -77,7 +77,7 @@ function addDependencies(): Rule {
     }
 
     // Add required dependencies
-    packageJsonContent.dependencies['ngxsmk-tel-input'] = '^1.8.4-beta.2';
+    packageJsonContent.dependencies['ngxsmk-tel-input'] = '^1.8.4-beta.3';
     packageJsonContent.dependencies['intl-tel-input'] = '^25.3.2';
     packageJsonContent.dependencies['libphonenumber-js'] = '^1.12.11';
 

--- a/projects/ngxsmk-tel-input/schematics/ng-add/index.ts
+++ b/projects/ngxsmk-tel-input/schematics/ng-add/index.ts
@@ -77,7 +77,7 @@ function addDependencies(): Rule {
     }
 
     // Add required dependencies
-    packageJsonContent.dependencies['ngxsmk-tel-input'] = '^1.8.4-beta.3';
+    packageJsonContent.dependencies['ngxsmk-tel-input'] = '^1.8.4-beta.4';
     packageJsonContent.dependencies['intl-tel-input'] = '^25.3.2';
     packageJsonContent.dependencies['libphonenumber-js'] = '^1.12.11';
 

--- a/projects/ngxsmk-tel-input/schematics/ng-add/index.ts
+++ b/projects/ngxsmk-tel-input/schematics/ng-add/index.ts
@@ -77,7 +77,7 @@ function addDependencies(): Rule {
     }
 
     // Add required dependencies
-    packageJsonContent.dependencies['ngxsmk-tel-input'] = '^1.8.3';
+    packageJsonContent.dependencies['ngxsmk-tel-input'] = '^1.8.4';
     packageJsonContent.dependencies['intl-tel-input'] = '^25.3.2';
     packageJsonContent.dependencies['libphonenumber-js'] = '^1.12.11';
 

--- a/projects/ngxsmk-tel-input/schematics/ng-add/index.ts
+++ b/projects/ngxsmk-tel-input/schematics/ng-add/index.ts
@@ -77,7 +77,7 @@ function addDependencies(): Rule {
     }
 
     // Add required dependencies
-    packageJsonContent.dependencies['ngxsmk-tel-input'] = '^1.8.4-beta.4';
+    packageJsonContent.dependencies['ngxsmk-tel-input'] = '^1.8.4';
     packageJsonContent.dependencies['intl-tel-input'] = '^25.3.2';
     packageJsonContent.dependencies['libphonenumber-js'] = '^1.12.11';
 

--- a/projects/ngxsmk-tel-input/schematics/ng-add/index.ts
+++ b/projects/ngxsmk-tel-input/schematics/ng-add/index.ts
@@ -77,7 +77,7 @@ function addDependencies(): Rule {
     }
 
     // Add required dependencies
-    packageJsonContent.dependencies['ngxsmk-tel-input'] = '^1.8.4-beta.0';
+    packageJsonContent.dependencies['ngxsmk-tel-input'] = '^1.8.4-beta.1';
     packageJsonContent.dependencies['intl-tel-input'] = '^25.3.2';
     packageJsonContent.dependencies['libphonenumber-js'] = '^1.12.11';
 

--- a/projects/ngxsmk-tel-input/src/lib/ngxsmk-tel-input.component.scss
+++ b/projects/ngxsmk-tel-input/src/lib/ngxsmk-tel-input.component.scss
@@ -342,16 +342,29 @@
   .ngxsmk-tel[data-size="sm"] ::ng-deep .iti__country-list {
     .iti__search-input {
       font-size: 12px !important;
-      padding: 6px 28px 6px 10px !important;
+      padding: 6px 28px 6px 28px !important;
       margin: 6px !important;
       width: calc(100% - 12px) !important;
       border-radius: 6px !important;
+    }
+
+    .iti__search-icon {
+      inset-inline-start: 14px !important;
+      inset-inline-end: auto !important;
+      top: 50% !important;
+      transform: translateY(-50%) !important;
+    }
+
+    .iti__search-icon-svg {
+      width: 12px !important;
+      height: 12px !important;
     }
     
     .iti__search-clear {
       width: 20px !important;
       height: 20px !important;
-      right: 10px !important;
+      inset-inline-end: 14px !important;
+      inset-inline-start: auto !important;
       
       svg {
         width: 10px;
@@ -384,16 +397,29 @@
   .ngxsmk-tel[data-size="lg"] ::ng-deep .iti__country-list {
     .iti__search-input {
       font-size: 15px !important;
-      padding: 10px 36px 10px 14px !important;
+      padding: 10px 42px 10px 42px !important;
       margin: 10px !important;
       width: calc(100% - 20px) !important;
       border-radius: 10px !important;
+    }
+
+    .iti__search-icon {
+      inset-inline-start: 22px !important;
+      inset-inline-end: auto !important;
+      top: 50% !important;
+      transform: translateY(-50%) !important;
+    }
+
+    .iti__search-icon-svg {
+      width: 16px !important;
+      height: 16px !important;
     }
     
     .iti__search-clear {
       width: 28px !important;
       height: 28px !important;
-      right: 16px !important;
+      inset-inline-end: 22px !important;
+      inset-inline-start: auto !important;
       
       svg {
         width: 14px;
@@ -560,7 +586,7 @@
   position: sticky;
   top: 0;
   margin: 8px;
-  padding: 8px 32px 8px 12px;
+  padding: 8px 36px 8px 36px !important;
   width: calc(100% - 16px);
   border: 1px solid var(--tel-border);
   border-radius: 8px;
@@ -583,10 +609,31 @@
   position: relative;
 }
 
+/* Search icon for search input */
+:host ::ng-deep .iti__search-icon {
+  position: absolute;
+  inset-inline-start: 18px !important;
+  inset-inline-end: auto !important;
+  top: 50% !important;
+  transform: translateY(-50%) !important;
+  display: flex;
+  pointer-events: none;
+  z-index: 10;
+}
+
+:host ::ng-deep .iti__search-icon-svg {
+  stroke: var(--tel-placeholder) !important;
+  fill: none;
+  stroke-width: 3;
+  width: 14px;
+  height: 14px;
+}
+
 /* Clear button for search input */
 :host ::ng-deep .iti__search-clear {
   position: absolute;
-  right: 14px;
+  inset-inline-end: 18px !important;
+  inset-inline-start: auto !important;
   top: 50%;
   transform: translateY(-50%);
   background: transparent;
@@ -1056,14 +1103,16 @@
   }
 
   :host ::ng-deep .iti__search-input {
-    padding-right: 36px !important;
+    padding-inline-start: 36px !important;
+    padding-inline-end: 36px !important;
   }
 
   :host ::ng-deep .iti__search-clear {
     width: 28px !important;
     height: 28px !important;
     font-size: 20px !important;
-    right: 6px !important;
+    inset-inline-end: 14px !important;
+    inset-inline-start: auto !important;
   }
 
   :host ::ng-deep .iti__country {
@@ -1110,7 +1159,8 @@
 
   :host ::ng-deep .iti__search-input {
     font-size: 16px !important;
-    padding: 12px 14px;
+    padding-block: 12px;
+    padding-inline: 36px !important;
     min-height: 44px;
     width: 100% !important;
     box-sizing: border-box;
@@ -1229,14 +1279,16 @@
   }
 
   :host ::ng-deep .iti__search-input {
-    padding-right: 36px !important;
+    padding-inline-start: 36px !important;
+    padding-inline-end: 36px !important;
   }
 
   :host ::ng-deep .iti__search-clear {
     width: 24px !important;
     height: 24px !important;
     font-size: 18px !important;
-    right: 6px !important;
+    inset-inline-end: 14px !important;
+    inset-inline-start: auto !important;
   }
 
   :host ::ng-deep .iti__country {
@@ -1275,7 +1327,8 @@
 
   :host ::ng-deep .iti__search-input {
     font-size: 16px !important;
-    padding: 10px 12px;
+    padding-block: 10px;
+    padding-inline: 36px !important;
     min-height: 44px;
   }
 

--- a/projects/ngxsmk-tel-input/src/lib/ngxsmk-tel-input.component.spec.ts
+++ b/projects/ngxsmk-tel-input/src/lib/ngxsmk-tel-input.component.spec.ts
@@ -653,7 +653,7 @@ describe('NgxsmkTelInputComponent', () => {
   });
 
   describe('Form Integration and DI fixes', () => {
-    it('should submit closest form on Enter keypress', () => {
+    it('should submit closest form on Enter keypress', fakeAsync(() => {
       TestBed.resetTestingModule();
       TestBed.configureTestingModule({
         imports: [TestFormSubmissionComponent],
@@ -671,13 +671,14 @@ describe('NgxsmkTelInputComponent', () => {
 
       const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
       inputEl.dispatchEvent(event);
+      tick();
       wrapperFixture.detectChanges();
 
       expect(submitSpy).toHaveBeenCalled();
       expect(componentInstance.submitted).toBeTrue();
-    });
+    }));
 
-    it('should submit closest form on Enter keypress when using formGroup and formControlName', () => {
+    it('should submit closest form on Enter keypress when using formGroup and formControlName', fakeAsync(() => {
       TestBed.resetTestingModule();
       TestBed.configureTestingModule({
         imports: [TestFormGroupSubmissionComponent],
@@ -695,11 +696,12 @@ describe('NgxsmkTelInputComponent', () => {
 
       const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
       inputEl.dispatchEvent(event);
+      tick();
       wrapperFixture.detectChanges();
 
       expect(submitSpy).toHaveBeenCalled();
       expect(componentInstance.submitted).toBeTrue();
-    });
+    }));
 
     it('should not throw runtime error when nested under a CVA component that uses formControl', () => {
       TestBed.resetTestingModule();

--- a/projects/ngxsmk-tel-input/src/lib/ngxsmk-tel-input.component.spec.ts
+++ b/projects/ngxsmk-tel-input/src/lib/ngxsmk-tel-input.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { PLATFORM_ID, Component, forwardRef } from '@angular/core';
-import { FormControl, ReactiveFormsModule, NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
+import { FormControl, FormGroup, ReactiveFormsModule, NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { NgxsmkTelInputComponent } from './ngxsmk-tel-input.component';
@@ -110,6 +110,7 @@ describe('NgxsmkTelInputComponent', () => {
       const callback = jasmine.createSpy('onTouched');
       component.registerOnTouched(callback);
       
+      (component as any).initialized = true;
       component.focused = true;
       component.onBlur();
       expect(callback).toHaveBeenCalled();
@@ -119,6 +120,7 @@ describe('NgxsmkTelInputComponent', () => {
       const callback = jasmine.createSpy('onTouched');
       component.registerOnTouched(callback);
       
+      (component as any).initialized = true;
       component.focused = false;
       component.onBlur();
       expect(callback).not.toHaveBeenCalled();
@@ -675,6 +677,30 @@ describe('NgxsmkTelInputComponent', () => {
       expect(componentInstance.submitted).toBeTrue();
     });
 
+    it('should submit closest form on Enter keypress when using formGroup and formControlName', () => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [TestFormGroupSubmissionComponent],
+        providers: [NgxsmkTelInputService]
+      });
+
+      const wrapperFixture = TestBed.createComponent(TestFormGroupSubmissionComponent);
+      wrapperFixture.detectChanges();
+
+      const componentInstance = wrapperFixture.componentInstance;
+      const submitSpy = spyOn(componentInstance, 'onSubmit').and.callThrough();
+
+      const inputEl = wrapperFixture.nativeElement.querySelector('input');
+      expect(inputEl).toBeTruthy();
+
+      const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
+      inputEl.dispatchEvent(event);
+      wrapperFixture.detectChanges();
+
+      expect(submitSpy).toHaveBeenCalled();
+      expect(componentInstance.submitted).toBeTrue();
+    });
+
     it('should not throw runtime error when nested under a CVA component that uses formControl', () => {
       TestBed.resetTestingModule();
       TestBed.configureTestingModule({
@@ -747,5 +773,25 @@ class WrapperCvaComponent implements ControlValueAccessor {
 })
 class TestParentControlComponent {
   control = new FormControl('');
+}
+
+@Component({
+  template: `
+    <form [formGroup]="form" (submit)="onSubmit($event)">
+      <ngxsmk-tel-input formControlName="phone"></ngxsmk-tel-input>
+    </form>
+  `,
+  standalone: true,
+  imports: [NgxsmkTelInputComponent, ReactiveFormsModule]
+})
+class TestFormGroupSubmissionComponent {
+  form = new FormGroup({
+    phone: new FormControl('')
+  });
+  submitted = false;
+  onSubmit(event: Event) {
+    event.preventDefault();
+    this.submitted = true;
+  }
 }
 

--- a/projects/ngxsmk-tel-input/src/lib/ngxsmk-tel-input.component.spec.ts
+++ b/projects/ngxsmk-tel-input/src/lib/ngxsmk-tel-input.component.spec.ts
@@ -110,8 +110,18 @@ describe('NgxsmkTelInputComponent', () => {
       const callback = jasmine.createSpy('onTouched');
       component.registerOnTouched(callback);
       
+      component.focused = true;
       component.onBlur();
       expect(callback).toHaveBeenCalled();
+    });
+
+    it('should not mark control as touched on blur if not previously focused', () => {
+      const callback = jasmine.createSpy('onTouched');
+      component.registerOnTouched(callback);
+      
+      component.focused = false;
+      component.onBlur();
+      expect(callback).not.toHaveBeenCalled();
     });
 
     it('should set disabled state', () => {
@@ -189,7 +199,7 @@ describe('NgxsmkTelInputComponent', () => {
       expect(errors).toBeNull();
     });
 
-    it('should emit validityChange when validity changes', () => {
+    it('should emit validityChange when validity changes', fakeAsync(() => {
       spyOn(component.validityChange, 'emit');
       const control = new FormControl('2025551234');
       
@@ -203,8 +213,9 @@ describe('NgxsmkTelInputComponent', () => {
       });
       
       component.validate(control);
+      tick();
       expect(component.validityChange.emit).toHaveBeenCalledWith(true);
-    });
+    }));
   });
 
   describe('Public Methods', () => {

--- a/projects/ngxsmk-tel-input/src/lib/ngxsmk-tel-input.component.ts
+++ b/projects/ngxsmk-tel-input/src/lib/ngxsmk-tel-input.component.ts
@@ -173,7 +173,7 @@ interface BeforeInputEvent extends Event {
             [attr.aria-errormessage]="showError() && resolvedErrorText() && (showErrorMsgSignal() ?? showErrorMsg) ? resolvedId + '-error' : null"
             (blur)="onBlur()"
             (focus)="onFocus()"
-            (keydown.enter)="onEnterPressed()"
+            (keydown.enter)="onEnterPressed($event)"
           />
         </div>
 
@@ -1332,7 +1332,7 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterContentIni
     });
   }
 
-  onEnterPressed() {
+  onEnterPressed(event: Event) {
     if (this.isDestroyed) return;
 
     this.touched = true;
@@ -1346,6 +1346,22 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterContentIni
       this.validatorChange?.();
     });
     this.cdr.markForCheck();
+
+    // Programmatically submit the closest form to trigger (submit) / (ngSubmit).
+    // This runs synchronously (no setTimeout) to stay in the Angular zone.
+    const form = this.hostElementRef.nativeElement.closest('form');
+    if (form) {
+      try {
+        if (typeof form.requestSubmit === 'function') {
+          form.requestSubmit();
+        } else {
+          form.dispatchEvent(new Event('submit', { cancelable: true, bubbles: true }));
+        }
+      } catch (e) {
+        // Fallback if requestSubmit throws (e.g. no submit button)
+        form.dispatchEvent(new Event('submit', { cancelable: true, bubbles: true }));
+      }
+    }
   }
 
   private handleInput() {

--- a/projects/ngxsmk-tel-input/src/lib/ngxsmk-tel-input.component.ts
+++ b/projects/ngxsmk-tel-input/src/lib/ngxsmk-tel-input.component.ts
@@ -254,6 +254,26 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterContentIni
         this.cdr.markForCheck();
       }
     }
+
+    if (this.ngControl && this.ngControl.control) {
+      const control = this.ngControl.control;
+      try {
+        if (control.validator) {
+          const testControl = { value: null } as AbstractControl;
+          const errors = control.validator(testControl);
+          const req = !!errors?.['required'];
+          if (this.isRequired !== req) {
+            this.isRequired = req;
+            this.stateChanges.next();
+          }
+        } else if (this.isRequired) {
+          this.isRequired = false;
+          this.stateChanges.next();
+        }
+      } catch (error) {
+        this.reportNonCriticalError('validate:required-check', error);
+      }
+    }
   }
 
   // ========== Signal-based API (Angular 17+) ==========
@@ -825,6 +845,8 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterContentIni
         errors: validationErrors
       }));
 
+      this.checkAndEmitValidity(parsed.isValid && !parsed.isInvalidInternational);
+
       this.lastActiveCountry = iso2;
       this.stateChanges.next();
       // Emit inputChange for external listeners (but NOT onChange to avoid loop)
@@ -872,22 +894,6 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterContentIni
   validate(control: AbstractControl): ValidationErrors | null {
     if (this.isDestroyed) return null;
 
-    // Update isRequired based on control validators
-    // Check if control has required validator by testing with null value
-    try {
-      if (control.validator) {
-        const testControl = { value: null } as AbstractControl;
-        const errors = control.validator(testControl);
-        this.isRequired = !!errors?.['required'];
-      } else {
-        this.isRequired = false;
-      }
-    } catch (error) {
-      // Fallback to not required if validator check fails
-      this.reportNonCriticalError('validate:required-check', error);
-      this.isRequired = false;
-    }
-
     const raw = this.currentRaw();
     if (!raw) return null;
 
@@ -897,19 +903,21 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterContentIni
     if (valid !== this.lastEmittedValid) {
       this.lastEmittedValid = valid;
 
-      // Update state signal
+      // Defer stateSignal update and output emissions to a microtask to avoid NG0600 during template rendering
       const validationErrors = this.buildValidationErrors(parsed.isValid, parsed.isInvalidInternational);
-      this.stateSignal.update(state => ({
-        ...state,
-        isValid: valid,
-        errors: validationErrors
-      }));
+      Promise.resolve().then(() => {
+        if (!this.isDestroyed) {
+          this.stateSignal.update(state => ({
+            ...state,
+            isValid: valid,
+            errors: validationErrors
+          }));
+          this.validityChange.emit(valid);
+          this.validityChangeSignal.emit(valid);
+          this.cdr.markForCheck();
+        }
+      });
 
-      // Emit both traditional and signal-based outputs
-      this.validityChange.emit(valid);
-      this.validityChangeSignal.emit(valid);
-
-      // Mark for check when validity changes
       this.cdr.markForCheck();
     }
 
@@ -921,6 +929,17 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterContentIni
     }
 
     return null;
+  }
+
+  private checkAndEmitValidity(valid: boolean): void {
+    if (valid !== this.lastEmittedValid) {
+      this.lastEmittedValid = valid;
+      this.runInZone(() => {
+        if (this.isDestroyed) return;
+        this.validityChange.emit(valid);
+        this.validityChangeSignal.emit(valid);
+      });
+    }
   }
 
   /**
@@ -1242,10 +1261,12 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterContentIni
 
   onBlur() {
     if (this.reinitInProgress) return;
+    const wasFocused = this.focused;
     this.focused = false;
     this.stateChanges.next();
 
     if (this.isDestroyed) return;
+    if (!wasFocused) return;
 
     this.touched = true;
 
@@ -1275,6 +1296,7 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterContentIni
     const nsn = parsed.e164 ? this.nsnFromE164(parsed.e164, iso2) : digits;
     if (formatWhenValidBlur !== 'typing') {
       this.setInputValue(this.displayValue(nsn, iso2));
+      this.checkAndEmitValidity(parsed.isValid && !parsed.isInvalidInternational);
     }
   }
 
@@ -1305,6 +1327,8 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterContentIni
   onEnterPressed(event: Event) {
     if (this.isDestroyed) return;
 
+    event.preventDefault();
+
     this.touched = true;
     this.stateSignal.update(state => ({
       ...state,
@@ -1319,10 +1343,23 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterContentIni
 
     const form = this.hostElementRef.nativeElement.closest('form');
     if (form) {
-      if (typeof form.requestSubmit === 'function') {
-        form.requestSubmit();
+      const submitBtn = form.querySelector('button[type="submit"], input[type="submit"]') as HTMLElement | null;
+      if (submitBtn) {
+        submitBtn.click();
       } else {
-        form.dispatchEvent(new Event('submit', { cancelable: true, bubbles: true }));
+        const submitEvent = new Event('submit', { cancelable: true, bubbles: true });
+        form.dispatchEvent(submitEvent);
+        if (!submitEvent.defaultPrevented) {
+          try {
+            if (typeof form.requestSubmit === 'function') {
+              form.requestSubmit();
+            } else {
+              form.submit();
+            }
+          } catch (e) {
+            // Ignore
+          }
+        }
       }
     }
   }
@@ -1348,6 +1385,8 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterContentIni
       isValid,
       errors: validationErrors
     }));
+
+    this.checkAndEmitValidity(isValid);
 
     // Intelligence features
     if (this.enableIntelligence && this.intelligence && parsed.e164) {

--- a/projects/ngxsmk-tel-input/src/lib/ngxsmk-tel-input.component.ts
+++ b/projects/ngxsmk-tel-input/src/lib/ngxsmk-tel-input.component.ts
@@ -26,6 +26,8 @@ import {
   HostBinding,
   Injector,
   DoCheck,
+  Self,
+  AfterContentInit,
 } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 import {
@@ -206,15 +208,12 @@ interface BeforeInputEvent extends Event {
   `,
   styleUrls: ['./ngxsmk-tel-input.component.scss'],
   providers: [
-    { provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => NgxsmkTelInputComponent), multi: true },
-    { provide: NG_VALIDATORS, useExisting: forwardRef(() => NgxsmkTelInputComponent), multi: true },
     { provide: MatFormFieldControl, useExisting: forwardRef(() => NgxsmkTelInputComponent) }
   ]
 })
-export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterViewInit, OnChanges, OnDestroy, ControlValueAccessor, Validator, MatFormFieldControl<string | null> {
+export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterContentInit, AfterViewInit, OnChanges, OnDestroy, ControlValueAccessor, Validator, MatFormFieldControl<string | null> {
   @ViewChild('telInput', { static: true }) inputRef!: ElementRef<HTMLInputElement>;
 
-  private readonly injector = inject(Injector);
   ngControl: NgControl | null = null;
 
   @HostBinding('class.ion-touched') get ionTouched() { return this.ngControl?.touched ?? false; }
@@ -233,8 +232,16 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterViewInit, 
 
   isNativelyDisabled = false;
 
-  ngOnInit(): void {
-    this.ngControl = this.injector.get(NgControl, null, { optional: true, self: true } as any);
+  ngOnInit(): void {}
+
+  ngAfterContentInit(): void {
+    if (this.ngControl) {
+      const control = this.ngControl.control;
+      if (control) {
+        control.addValidators((ctrl) => this.validate(ctrl));
+        control.updateValueAndValidity({ emitEvent: false });
+      }
+    }
   }
 
   ngDoCheck(): void {
@@ -566,8 +573,13 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterViewInit, 
   constructor(
     @Optional() private readonly zone: NgZone | null,
     private readonly tel: NgxsmkTelInputService,
-    private readonly cdr: ChangeDetectorRef
+    private readonly cdr: ChangeDetectorRef,
+    @Self() @Optional() ngControl: NgControl
   ) {
+    this.ngControl = ngControl;
+    if (this.ngControl) {
+      this.ngControl.valueAccessor = this;
+    }
     // Watch for theme signal changes
     effect(() => {
       if (!isPlatformBrowser(this.platformId) || this.isDestroyed) return;
@@ -1290,6 +1302,19 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterViewInit, 
 
   onEnterPressed(event: Event) {
     if (this.isDestroyed) return;
+
+    this.touched = true;
+    this.stateSignal.update(state => ({
+      ...state,
+      touched: true
+    }));
+
+    this.runInZone(() => {
+      this.onTouchedCb();
+      this.validatorChange?.();
+    });
+    this.cdr.markForCheck();
+
     const form = this.hostElementRef.nativeElement.closest('form');
     if (form) {
       if (typeof form.requestSubmit === 'function') {

--- a/projects/ngxsmk-tel-input/src/lib/ngxsmk-tel-input.component.ts
+++ b/projects/ngxsmk-tel-input/src/lib/ngxsmk-tel-input.component.ts
@@ -33,8 +33,9 @@ import { isPlatformBrowser } from '@angular/common';
 import {
   AbstractControl,
   ControlValueAccessor,
-  NG_VALIDATORS,
+  FormsModule,
   NG_VALUE_ACCESSOR,
+  ReactiveFormsModule,
   ValidationErrors,
   Validator,
   NgControl
@@ -138,7 +139,7 @@ interface BeforeInputEvent extends Event {
 @Component({
   selector: 'ngxsmk-tel-input',
   standalone: true,
-  imports: [],
+  imports: [ReactiveFormsModule, FormsModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
       <div class="ngxsmk-tel"
@@ -172,7 +173,7 @@ interface BeforeInputEvent extends Event {
             [attr.aria-errormessage]="showError() && resolvedErrorText() && (showErrorMsgSignal() ?? showErrorMsg) ? resolvedId + '-error' : null"
             (blur)="onBlur()"
             (focus)="onFocus()"
-            (keydown.enter)="onEnterPressed($event)"
+            (keydown.enter)="onEnterPressed()"
           />
         </div>
 
@@ -210,6 +211,9 @@ interface BeforeInputEvent extends Event {
   providers: [
     { provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => NgxsmkTelInputComponent), multi: true },
     { provide: MatFormFieldControl, useExisting: forwardRef(() => NgxsmkTelInputComponent) }
+  ],
+  viewProviders: [
+    { provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => NgxsmkTelInputComponent), multi: true }
   ]
 })
 export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterContentInit, AfterViewInit, OnChanges, OnDestroy, ControlValueAccessor, Validator, MatFormFieldControl<string | null> {
@@ -236,7 +240,7 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterContentIni
   isNativelyDisabled = false;
 
   ngOnInit(): void {
-    this.ngControl = this.injector.get(NgControl, null);
+    this.ngControl = this.injector.get(NgControl, null, { self: true, optional: true });
   }
 
   ngAfterContentInit(): void {
@@ -714,6 +718,8 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterContentIni
     await this.initIntlTelInput();
     if (this.isDestroyed) return;
 
+    this.initialized = true;
+
     this.bindDomListeners();
 
     if (this.pendingWrite !== null && !this.isDestroyed) {
@@ -727,12 +733,6 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterContentIni
         if (!this.isDestroyed) this.focus();
       });
     }
-
-    setTimeout(() => {
-      if (!this.isDestroyed) {
-        this.initialized = true;
-      }
-    }, 50);
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -900,6 +900,10 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterContentIni
   validate(control: AbstractControl): ValidationErrors | null {
     if (this.isDestroyed) return null;
 
+    if (!control || control.value === null || control.value === undefined || control.value === '') {
+      return null;
+    }
+
     const raw = this.currentRaw();
     if (!raw) return null;
 
@@ -1064,10 +1068,10 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterContentIni
     const prevIso2 = (this.iti?.getSelectedCountryData?.().iso2 || this.initialCountry || 'US').toString().toLowerCase();
     const prevValue = this.currentRaw();
 
-    this.initialized = false;
     this.cleanupEventListeners();
     this.destroyPlugin();
     await this.initIntlTelInput();
+    this.initialized = true;
     this.bindDomListeners();
 
     if (!this.isDestroyed) {
@@ -1083,12 +1087,6 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterContentIni
       }
       this.applyDisabledUi(this.disabled);
       this.lastActiveCountry = this.currentIso2();
-
-      setTimeout(() => {
-        if (!this.isDestroyed) {
-          this.initialized = true;
-        }
-      }, 50);
     }
   }
 
@@ -1253,17 +1251,12 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterContentIni
         this.handleInput();
       };
 
-      const blurHandler = () => {
-        if (!this.isDestroyed) this.onBlur();
-      };
-
       // Store listeners for cleanup
       this.eventListeners = [
         { element: el, event: 'beforeinput', handler: beforeInputHandler },
         { element: el, event: 'paste', handler: pasteHandler },
         { element: el, event: 'input', handler: inputHandler },
-        { element: el, event: 'countrychange', handler: countryChangeHandler },
-        { element: el, event: 'blur', handler: blurHandler }
+        { element: el, event: 'countrychange', handler: countryChangeHandler }
       ];
 
       this.eventListeners.forEach(({ element, event, handler }) => {
@@ -1339,10 +1332,8 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterContentIni
     });
   }
 
-  onEnterPressed(event: Event) {
+  onEnterPressed() {
     if (this.isDestroyed) return;
-
-    event.preventDefault();
 
     this.touched = true;
     this.stateSignal.update(state => ({
@@ -1355,31 +1346,6 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterContentIni
       this.validatorChange?.();
     });
     this.cdr.markForCheck();
-
-    // Try to submit the native form
-    const form = this.hostElementRef.nativeElement.closest('form');
-    if (form) {
-      const submitBtn = form.querySelector('button:not([type]), button[type="submit"], input[type="submit"]') as HTMLElement | null;
-      if (submitBtn) {
-        if (!submitBtn.matches(':disabled')) {
-          submitBtn.click();
-        }
-      } else {
-        const submitEvent = new Event('submit', { cancelable: true, bubbles: true });
-        form.dispatchEvent(submitEvent);
-        if (!submitEvent.defaultPrevented) {
-          try {
-            if (typeof form.requestSubmit === 'function') {
-              form.requestSubmit();
-            } else {
-              form.submit();
-            }
-          } catch (e) {
-            // Ignore
-          }
-        }
-      }
-    }
   }
 
   private handleInput() {

--- a/projects/ngxsmk-tel-input/src/lib/ngxsmk-tel-input.component.ts
+++ b/projects/ngxsmk-tel-input/src/lib/ngxsmk-tel-input.component.ts
@@ -1039,6 +1039,7 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterContentIni
     const prevIso2 = (this.iti?.getSelectedCountryData?.().iso2 || this.initialCountry || 'US').toString().toLowerCase();
     const prevValue = this.currentRaw();
 
+    this.cleanupEventListeners();
     this.destroyPlugin();
     await this.initIntlTelInput();
     this.bindDomListeners();
@@ -1240,6 +1241,7 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterContentIni
   }
 
   onBlur() {
+    if (this.reinitInProgress) return;
     this.focused = false;
     this.stateChanges.next();
 

--- a/projects/ngxsmk-tel-input/src/lib/ngxsmk-tel-input.component.ts
+++ b/projects/ngxsmk-tel-input/src/lib/ngxsmk-tel-input.component.ts
@@ -208,6 +208,7 @@ interface BeforeInputEvent extends Event {
   `,
   styleUrls: ['./ngxsmk-tel-input.component.scss'],
   providers: [
+    { provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => NgxsmkTelInputComponent), multi: true },
     { provide: MatFormFieldControl, useExisting: forwardRef(() => NgxsmkTelInputComponent) }
   ]
 })
@@ -215,6 +216,8 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterContentIni
   @ViewChild('telInput', { static: true }) inputRef!: ElementRef<HTMLInputElement>;
 
   ngControl: NgControl | null = null;
+  private readonly injector = inject(Injector);
+  private initialized = false;
 
   @HostBinding('class.ion-touched') get ionTouched() { return this.ngControl?.touched ?? false; }
   @HostBinding('class.ion-untouched') get ionUntouched() { return this.ngControl?.untouched ?? false; }
@@ -232,7 +235,9 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterContentIni
 
   isNativelyDisabled = false;
 
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    this.ngControl = this.injector.get(NgControl, null);
+  }
 
   ngAfterContentInit(): void {
     if (this.ngControl) {
@@ -593,13 +598,8 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterContentIni
   constructor(
     @Optional() private readonly zone: NgZone | null,
     private readonly tel: NgxsmkTelInputService,
-    private readonly cdr: ChangeDetectorRef,
-    @Self() @Optional() ngControl: NgControl
+    private readonly cdr: ChangeDetectorRef
   ) {
-    this.ngControl = ngControl;
-    if (this.ngControl) {
-      this.ngControl.valueAccessor = this;
-    }
     // Watch for theme signal changes
     effect(() => {
       if (!isPlatformBrowser(this.platformId) || this.isDestroyed) return;
@@ -727,6 +727,12 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterContentIni
         if (!this.isDestroyed) this.focus();
       });
     }
+
+    setTimeout(() => {
+      if (!this.isDestroyed) {
+        this.initialized = true;
+      }
+    }, 50);
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -1058,6 +1064,7 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterContentIni
     const prevIso2 = (this.iti?.getSelectedCountryData?.().iso2 || this.initialCountry || 'US').toString().toLowerCase();
     const prevValue = this.currentRaw();
 
+    this.initialized = false;
     this.cleanupEventListeners();
     this.destroyPlugin();
     await this.initIntlTelInput();
@@ -1076,6 +1083,12 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterContentIni
       }
       this.applyDisabledUi(this.disabled);
       this.lastActiveCountry = this.currentIso2();
+
+      setTimeout(() => {
+        if (!this.isDestroyed) {
+          this.initialized = true;
+        }
+      }, 50);
     }
   }
 
@@ -1260,6 +1273,7 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterContentIni
   }
 
   onBlur() {
+    if (!this.initialized) return;
     if (this.reinitInProgress) return;
     const wasFocused = this.focused;
     this.focused = false;
@@ -1301,6 +1315,7 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterContentIni
   }
 
   onFocus() {
+    if (!this.initialized) return;
     this.focused = true;
     this.stateChanges.next();
 
@@ -1341,11 +1356,14 @@ export class NgxsmkTelInputComponent implements OnInit, DoCheck, AfterContentIni
     });
     this.cdr.markForCheck();
 
+    // Try to submit the native form
     const form = this.hostElementRef.nativeElement.closest('form');
     if (form) {
-      const submitBtn = form.querySelector('button[type="submit"], input[type="submit"]') as HTMLElement | null;
+      const submitBtn = form.querySelector('button:not([type]), button[type="submit"], input[type="submit"]') as HTMLElement | null;
       if (submitBtn) {
-        submitBtn.click();
+        if (!submitBtn.matches(':disabled')) {
+          submitBtn.click();
+        }
       } else {
         const submitEvent = new Event('submit', { cancelable: true, bubbles: true });
         form.dispatchEvent(submitEvent);


### PR DESCRIPTION
## v1.8.4

### Bug Fixes

- **No Value Accessor (NG01203)**: Added `ReactiveFormsModule` and `FormsModule` to component
  `imports` and `NG_VALUE_ACCESSOR` to `viewProviders` alongside `providers`, ensuring proper
  resolution for standalone components across all Angular DI scopes.

- **Touched state during initialization**: Removed the 50ms `setTimeout` delay on the `initialized`
  flag and eliminated the redundant native `blur` event listener. This prevents race conditions
  where intl-tel-input plugin events during setup could prematurely mark the field as touched.

- **Submit on Enter with `[formGroup]` / `[formControlName]`**: Replaced the unreliable
  `setTimeout`+`submitBtn.click()` fallback with synchronous `form.requestSubmit()` (with
  `dispatchEvent` fallback). This keeps execution inside the Angular zone and correctly fires
  both native `(submit)` and Angular `(ngSubmit)` handlers.

### Chores

- Updated version from `1.8.4-beta.4` → `1.8.4` across `package.json`, `package-lock.json`,
  schematics, demo app, and CHANGELOG.
- Updated CHANGELOG with v1.8.4 release notes.